### PR TITLE
Support for Traco as i18n db backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ActiveAdmin Translate Changelog
 
+## 0.3.0 - June 3, 2014
+
+- Support for [Traco](https://github.com/barsoom/traco) as i18n backend
+
 ## 0.2.2 - November 16, 2012
 
 - Include SCSS mixins.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # ActiveAdmin Translate
 
-Translate your [Globalize3](https://github.com/svenfuchs/globalize3) ActiveModel translations in
-[ActiveAdmin](https://github.com/gregbell/active_admin), using [jQueryUI tabs](http://jqueryui.com/tabs/) to switch
+Translate your [Globalize3](https://github.com/svenfuchs/globalize3)
+or [Traco](https://github.com/barsoom/traco) ActiveModel translations
+in [ActiveAdmin](https://github.com/gregbell/active_admin),
+using [jQueryUI tabs](http://jqueryui.com/tabs/) to switch
 between the locales.
 
 ## Installation
 
-Add the gem to your `Gemfile`
+Add the gem to your `Gemfile` with your i18n db backend `globalize3` or `traco`
 
 ```ruby
 gem 'activeadmin-translate'
+gem 'globalize3' # OR
+gem 'traco'
 ```
 
 and install it with Bundler:
@@ -37,9 +41,16 @@ You need to import the SASS for styling the tabs to `app/assets/stylesheets/acti
 @import "active_admin/translate";
 ```
 
+If `ActiveAdmin` has not already loaded jQuery UI tabs library,
+you need to manually require the file in `app/assets/stylesheets/active_admin.js.coffee`:
+
+```js
+#= require jquery.ui.tabs
+```
+
 ## Usage
 
-### Make your translations accessible
+### Make your translations accessible (Globalize3 only)
 
 In order to access the translations of your model and be able to write them on save, you need to make attributes
 accessible in your model. Globalize3 stores the model translations in a separate table that is accessible as
@@ -54,13 +65,21 @@ end
 
 ### Translate your ActiveAdmin forms
 
+
 To translate your form you need to use the `translate_inputs` form helper:
 
 ```ruby
 form do |f|
+  # globalize3:
   f.translate_inputs do |t|
     t.input :title
     t.input :description
+  end
+
+  # traco:
+  f.translate_inputs do |locale|
+    t.input :"title_#{locale}"
+    t.input :"description_#{locale}"
   end
 end
 ```
@@ -71,7 +90,7 @@ To show the attributes for all locales, you use the `translate_attributes_table_
 
 ```ruby
 show do |model|
-  panel 'Globalized Model' do
+  panel 'Localized Model' do
     translate_attributes_table_for model do
       row :title
       row :description do |p|

--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Michael Kessler']
   gem.email         = %w(michi@flinkfinger.com)
   gem.summary       = %q{Translate models with ActiveAdmin.}
-  gem.description   = %q{Translate your models in ActiveAdmin with Globalize3.}
+  gem.description   = %q{Translate your models in ActiveAdmin with Globalize3 or Traco.}
   gem.homepage      = 'https://github.com/netzpirat/activeadmin-translate'
 
   gem.files         = Dir['{app,lib,config}/**/*'] + %w(LICENSE README.md CHANGELOG.md CONTRIBUTING.md)
@@ -14,6 +14,5 @@ Gem::Specification.new do |gem|
   gem.version       = ActiveAdmin::Translate::VERSION
 
   gem.add_dependency 'activeadmin'
-  gem.add_dependency 'globalize3'
   gem.add_dependency 'railties'
 end

--- a/lib/active_admin/translate/backend.rb
+++ b/lib/active_admin/translate/backend.rb
@@ -1,0 +1,15 @@
+module ActiveAdmin
+  module Translate
+    class << self
+      attr_accessor :backend
+
+      def traco?
+        backend == :traco
+      end
+
+      def globalize?
+        backend == :globalize
+      end
+    end
+  end
+end

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -32,6 +32,34 @@ module ActiveAdmin
       # @param [Proc] block the block for the additional inputs
       #
       def locale_fields(name, block)
+        if ActiveAdmin::Translate.traco?
+          locale_fields_for_traco(name, block)
+        else
+          locale_fields_for_globalize(name, block)
+        end
+      end
+
+
+      def locale_fields_for_traco(name, block)
+        buffer = form_buffers.dup
+
+        fieldset = ::I18n.available_locales.map do |locale|
+          @form_buffers = ["".html_safe]
+
+          fields = proc do
+            block.call(locale)
+          end
+
+          inputs(name: name, :id => field_id(locale), :class => "inputs locale locale-#{locale}", &fields)
+        end.join.html_safe
+
+        @form_buffers = buffer
+
+        fieldset
+      end
+
+
+      def locale_fields_for_globalize(name, block)
         ::I18n.available_locales.map do |locale|
           translation = object.translation_for(locale)
           translation.instance_variable_set(:@errors, object.errors) if locale == I18n.default_locale

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.2'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/activeadmin-translate.rb
+++ b/lib/activeadmin-translate.rb
@@ -1,5 +1,13 @@
 require 'active_admin'
-require 'globalize3'
+require 'active_admin/translate/backend'
+
+ActiveAdmin::Translate.backend = begin
+  require 'traco'
+  :traco
+rescue LoadError
+  require 'globalize'
+  :globalize
+end
 
 require 'active_admin/version'
 require 'active_admin/translate/engine'


### PR DESCRIPTION
Hi !

In one of projects in the company I'm working for, we are using ActiveAdmin with [Traco](https://github.com/barsoom/traco) as i18n backend instead of globalize. The main difference is that i18n fields are in the same table as the model.
So, I decided to add support for Traco in activeadmin-translate.

Hope this will be useful for other people.
