### PR TITLE
'form_buffers' has been removed from ActiveAdmin::FormBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ActiveAdmin Translate Changelog
 
+## 0.2.3 - December 6, 2014
+
+- Remove Globalize3 dependency.
+- Fix UI tab issues.
+- Fix compatibility with current ActiveAdmin.
+
 ## 0.2.2 - November 16, 2012
 
 - Include SCSS mixins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ActiveAdmin Translate Changelog
 
+## 0.2.5 - March 27, 2015
+
+Updates content_for block to accept record object (Thanks David Stump)
+Add more locales
+
+## 0.2.4 - January 14, 2015
+
+- Add form_buffers backward compatibility
+
+
 ## 0.2.3 - December 6, 2014
 
 - Remove Globalize3 dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # ActiveAdmin Translate Changelog
 
+## 0.2.6 - November 24, 2015
+
+- Support for has_many translates (Thanks Pavel Borsky)
+
 ## 0.2.5 - March 27, 2015
 
-Updates content_for block to accept record object (Thanks David Stump)
-Add more locales
+- Updates content_for block to accept record object (Thanks David Stump)
+- Add more locales
 
 ## 0.2.4 - January 14, 2015
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ActiveAdmin Translate Changelog
 
+## 0.2.7 - December 23, 2015
+
+- Fixed problem when block f.translate_inputs called before f.inputs and only one input field rendered (Thanks Pavel Borsky)
+
 ## 0.2.6 - November 24, 2015
 
 - Support for has_many translates (Thanks Pavel Borsky)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contribute to ActiveAdmin Translate
 File an issue
 -------------
 
-You can report bugs and feature requests to [GitHub Issues](https://github.com/netzpirat/activeadmin-globalize/issues).
+You can report bugs and feature requests to [GitHub Issues](https://github.com/netzpirat/activeadmin-translate/issues).
 
 **Please don't ask question in the issue tracker**, instead ask them at Stackoverflow and use the
 [activeadmin](http://stackoverflow.com/questions/tagged/activeadmin) tag.
@@ -20,8 +20,7 @@ When you file a bug, please try to follow these simple rules if applicable:
 Development
 -----------
 
-* Documentation hosted at [RubyDoc](http://rubydoc.info/github/netzpirat/activeadmin-globalize/master/frames).
-* Source hosted at [GitHub](https://github.com/netzpirat/activeadmin-globalize).
+* Source hosted at [GitHub](https://github.com/netzpirat/activeadmin-translate).
 
 Pull requests are very welcome! Please try to follow these simple rules if applicable:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ between the locales.
 Add the gem to your `Gemfile`
 
 ```ruby
-gem 'activeadmin-translate'
+gem 'activeadmin-translate', github: 'rbatllet/activeadmin-globalize'
 ```
 
 and install it with Bundler:
@@ -142,7 +142,7 @@ See the [CHANGELOG](https://github.com/netzpirat/activeadmin-globalize/blob/mast
 
 This project has taken some ideas and code from the following projects:
 
-- [activeadmin-globalize3](https://github.com/stefanoverna/activeadmin-globalize3) from [Stefano Verna](https://github.com/stefanoverna)
+- [activeadmin-globalize](https://github.com/stefanoverna/activeadmin-globalize) from [Stefano Verna](https://github.com/stefanoverna)
 - [ActiveAdmin-Globalize3-inputs](https://github.com/mimimi/ActiveAdmin-Globalize3-inputs) from [Dmitrii Soltis](https://github.com/mimimi)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ActiveAdmin Translate
 
-Translate your [Globalize3](https://github.com/svenfuchs/globalize3) ActiveModel translations in
-[ActiveAdmin](https://github.com/gregbell/active_admin), using [jQueryUI tabs](http://jqueryui.com/tabs/) to switch
+Translate your [Globalize](https://github.com/globalize/globalize) ActiveModel translations in
+[ActiveAdmin](https://github.com/activeadmin/activeadmin), using [jQueryUI tabs](http://jqueryui.com/tabs/) to switch
 between the locales.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ActiveAdmin Translate takes the available languages from `I18n.available_locales
 your `application.rb` like
 
 ```ruby
-config.i18n.available_locales = [:en, :de, :fr, :it]
+config.i18n.available_locales = [:en, :de, :fr, :it, :es, :ca]
 ```
 
 ### Include ActiveAdmin Translate

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ between the locales.
 Add the gem to your `Gemfile`
 
 ```ruby
-gem 'activeadmin-translate', github: 'rbatllet/activeadmin-globalize'
+gem 'activeadmin-translate', github: 'rbatllet/activeadmin-translate'
 ```
 
 and install it with Bundler:
@@ -42,7 +42,7 @@ You need to import the SASS for styling the tabs to `app/assets/stylesheets/acti
 ### Make your translations accessible
 
 In order to access the translations of your model and be able to write them on save, you need to make attributes
-accessible in your model. Globalize3 stores the model translations in a separate table that is accessible as
+accessible in your model. Globalize stores the model translations in a separate table that is accessible as
 `translations` in your model:
 
 ```ruby
@@ -100,14 +100,14 @@ and add more translations with the registered locale symbol.
 Developed by Michael Kessler, [FlinkFinger GmbH](http://www.flinkfinger.com).
 
 If you like ActiveAdmin Translate, you can watch the repository at
-[GitHub](https://github.com/netzpirat/activeadmin-globalize) and follow [@netzpirat](https://twitter.com/#!/netzpirat)
+[GitHub](https://github.com/netzpirat/activeadmin-translate) and follow [@netzpirat](https://twitter.com/netzpirat)
 on Twitter for project updates.
 
 ## Contribute to ActiveAdmin Translate
 
 ### File an issue
 
-You can report bugs and feature requests to [GitHub Issues](https://github.com/netzpirat/activeadmin-globalize/issues).
+You can report bugs and feature requests to [GitHub Issues](https://github.com/netzpirat/activeadmin-translate/issues).
 
 **Please don't ask question in the issue tracker**, instead ask them at Stackoverflow and use the
 [activeadmin](http://stackoverflow.com/questions/tagged/activeadmin) tag.
@@ -122,21 +122,20 @@ When you file a bug, please try to follow these simple rules if applicable:
 
 ### Development
 
-* Documentation hosted at [RubyDoc](http://rubydoc.info/github/netzpirat/activeadmin-globalize/master/frames).
-* Source hosted at [GitHub](https://github.com/netzpirat/activeadmin-globalize).
+* Source hosted at [GitHub](https://github.com/netzpirat/activeadmin-translate).
 
 Pull requests are very welcome! Please try to follow these simple rules if applicable:
 
 * Please create a topic branch for every separate change you make.
 * Update the [Yard](http://yardoc.org/) documentation.
-* Update the [README](https://github.com/netzpirat/activeadmin-globalize/blob/master/README.md).
-* Update the [CHANGELOG](https://github.com/netzpirat/activeadmin-globalize/blob/master/CHANGELOG.md) for noteworthy changes.
+* Update the [README](https://github.com/netzpirat/activeadmin-translate/blob/master/README.md).
+* Update the [CHANGELOG](https://github.com/netzpirat/activeadmin-translate/blob/master/CHANGELOG.md) for noteworthy changes.
 * Please **do not change** the version number.
 
 ## Contributors
 
-See the [CHANGELOG](https://github.com/netzpirat/activeadmin-globalize/blob/master/CHANGELOG.md) and the GitHub list of
-[contributors](https://github.com/netzpirat/activeadmin-globalize/contributors).
+See the [CHANGELOG](https://github.com/netzpirat/activeadmin-translate/blob/master/CHANGELOG.md) and the GitHub list of
+[contributors](https://github.com/netzpirat/activeadmin-translate/contributors).
 
 ## Acknowledgment
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ between the locales.
 Add the gem to your `Gemfile`
 
 ```ruby
-gem 'activeadmin-translate', github: 'rbatllet/activeadmin-translate'
+gem 'activeadmin-translate', github: 'twintags/activeadmin-translate'
 ```
 
 and install it with Bundler:

--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -2,11 +2,11 @@
 require File.expand_path('../lib/active_admin/translate/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ['Michael Kessler']
+  gem.authors       = ['Michael Kessler', 'R. Batlle']
   gem.email         = %w(michi@flinkfinger.com)
   gem.summary       = %q{Translate models with ActiveAdmin.}
   gem.description   = %q{Translate your models in ActiveAdmin with Globalize.}
-  gem.homepage      = 'https://github.com/netzpirat/activeadmin-translate'
+  gem.homepage      = 'https://github.com/rbatllet/activeadmin-translate'
 
   gem.files         = Dir['{app,lib,config}/**/*'] + %w(LICENSE README.md CHANGELOG.md CONTRIBUTING.md)
   gem.name          = 'activeadmin-translate'

--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -2,11 +2,11 @@
 require File.expand_path('../lib/active_admin/translate/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ['Michael Kessler', 'R. Batlle']
+  gem.authors       = ['Michael Kessler', 'Twintags']
   gem.email         = %w(michi@flinkfinger.com)
   gem.summary       = %q{Translate models with ActiveAdmin.}
   gem.description   = %q{Translate your models in ActiveAdmin with Globalize.}
-  gem.homepage      = 'https://github.com/rbatllet/activeadmin-translate'
+  gem.homepage      = 'https://github.com/twintags/activeadmin-translate'
 
   gem.files         = Dir['{app,lib,config}/**/*'] + %w(LICENSE README.md CHANGELOG.md CONTRIBUTING.md)
   gem.name          = 'activeadmin-translate'

--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -5,15 +5,16 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Michael Kessler']
   gem.email         = %w(michi@flinkfinger.com)
   gem.summary       = %q{Translate models with ActiveAdmin.}
-  gem.description   = %q{Translate your models in ActiveAdmin with Globalize3.}
+  gem.description   = %q{Translate your models in ActiveAdmin with Globalize.}
   gem.homepage      = 'https://github.com/netzpirat/activeadmin-translate'
 
   gem.files         = Dir['{app,lib,config}/**/*'] + %w(LICENSE README.md CHANGELOG.md CONTRIBUTING.md)
   gem.name          = 'activeadmin-translate'
   gem.require_paths = %w(lib)
   gem.version       = ActiveAdmin::Translate::VERSION
+  gem.license       = 'MIT'
 
   gem.add_dependency 'activeadmin'
-  gem.add_dependency 'globalize3'
+  gem.add_dependency 'globalize'
   gem.add_dependency 'railties'
 end

--- a/app/assets/stylesheets/active_admin/translate.css.scss
+++ b/app/assets/stylesheets/active_admin/translate.css.scss
@@ -5,6 +5,7 @@
   .activeadmin-translate .locales {
     overflow: auto;
     margin-right: 10px;
+    margin-bottom: -1px;
 
     li {
       @include section-header;
@@ -12,10 +13,33 @@
       border-top-left-radius: 10px;
       border-top-right-radius: 10px;
 
-      float: right !important;
+      float: right;
+
+      margin-bottom: 0;
+      padding-left: 0;
+      padding-right: 0;
+
+      a {
+        padding: .5em 1em;
+        text-decoration: none;
+
+        &:hover,&:active {
+          text-decoration: underline;
+        }
+        box-shadow: none;
+        border-style: none;
+        background: inherit;
+      }
 
       &.ui-state-active {
         background: white;
+        border-bottom-color: white;
+
+        a {
+          color: $section-header-text-color;
+          cursor: default;
+          text-decoration: none;
+        }
       }
     }
   }
@@ -31,53 +55,4 @@
   .activeadmin-translate .ui-tabs-hide {
     display: none !important;
   }
-
-  .ui-tabs {
-    position: relative;
-    padding: .2em;
-    zoom: 1;
-  }
-
-  .ui-tabs .ui-tabs-nav {
-    margin: 0;
-    padding: .2em .2em 0;
-  }
-
-  .ui-tabs .ui-tabs-nav li {
-    list-style: none;
-    float: left;
-    position: relative;
-    top: 0;
-    margin: 1px .2em 0 0;
-    border-bottom: 0;
-    padding: 0;
-    white-space: nowrap;
-  }
-
-  .ui-tabs .ui-tabs-nav li a {
-    float: left;
-    padding: .5em 1em;
-    text-decoration: none;
-  }
-
-  .ui-tabs .ui-tabs-nav li.ui-tabs-active {
-    margin-bottom: -1px;
-    padding-bottom: 1px;
-  }
-
-  .ui-tabs .ui-tabs-nav li.ui-tabs-active a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-tabs-loading a {
-    cursor: text;
-  }
-
-  .ui-tabs .ui-tabs-nav li a, .ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-active a {
-    cursor: pointer;
-  }
-
-  .ui-tabs .ui-tabs-panel {
-    display: block;
-    border-width: 0;
-    padding: 1em 1.4em;
-    background: none;
-  }
-
 }

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,9 @@
+ca:
+  active_admin:
+    translate:
+      en: 'Anglès'
+      de: 'Alemany'
+      fr: 'Francès'
+      it: 'Italià'
+      es: 'Espanyol'
+      ca: 'Català'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -5,3 +5,5 @@ de:
       de: 'Deutsch'
       fr: 'Französich'
       it: 'Italienisch'
+      es: 'Spanisch'
+      ca: 'Katalanisch'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,5 +5,5 @@ en:
       de: 'German'
       fr: 'French'
       it: 'Italian'
-      es: 'Spanish'
-      ca: 'Catalan'
+      es: 'Español'
+      ca: 'Catalán'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,3 +5,5 @@ fr:
       de: 'Allemand'
       fr: 'Français'
       it: 'Italien'
+      es: 'Espagnol'
+      ca: 'Catalan'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,7 +1,9 @@
 it:
   active_admin:
     translate:
-      en: 'Inglese '
+      en: 'Inglese'
       de: 'Alemanno'
-      fr: 'Francese '
+      fr: 'Francese'
       it: 'Italiano'
+      es: 'Spagnolo'
+      ca: 'Catalano'

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       # @param [Proc] block the block for the additional inputs
       #
       def translate_inputs(name = :translations, &block)
-        form_buffers.last << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
+        template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs << locale_fields(name, block) << tab_script
         end
       end

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -11,7 +11,12 @@ module ActiveAdmin
       # @param [Proc] block the block for the additional inputs
       #
       def translate_inputs(name = :translations, &block)
-        template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
+        if self.respond_to?(:form_buffers)
+          html = form_buffers.last
+        else
+          html = "".html_safe
+        end
+        html << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs << locale_fields(name, block) << tab_script
         end
       end

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -16,9 +16,13 @@ module ActiveAdmin
         else
           html = "".html_safe
         end
+
         html << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs << locale_fields(name, block) << tab_script
         end
+
+        template.concat(html) if template.output_buffer
+        html
       end
 
       protected
@@ -43,7 +47,7 @@ module ActiveAdmin
 
           fields = proc do |form|
             form.input(:locale, :as => :hidden)
-            block.call(form)
+            block.call form
           end
 
           inputs_for_nested_attributes(:for => [name, translation], :id => field_id(locale), :class => "inputs locale locale-#{ locale }", &fields)

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -17,6 +17,8 @@ module ActiveAdmin
           html = "".html_safe
         end
 
+        template.assign(has_many_block: true)
+
         html << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs << locale_fields(name, block) << tab_script
         end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.5'
+    VERSION = '0.2.6'
   end
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'
   end
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.3'
+    VERSION = '0.2.4'
   end
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.4'
+    VERSION = '0.2.5'
   end
 end

--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
 
     # Adds a builder method `translate_attributes_table_for` to build a
     # table with translations for a model that has been localized with
-    # Globalize3.
+    # Globalize.
     #
     class TranslateAttributesTable < ::ActiveAdmin::Views::AttributesTable
 

--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -17,9 +17,11 @@ module ActiveAdmin
                 header_content_for(attr)
               end
             end
-            td do
-              ::I18n.with_locale locale do
-                content_for(block || attr)
+            @collection.each do |record|
+              td do
+                ::I18n.with_locale locale do
+                  content_for(record, block || attr)
+                end
               end
             end
           end

--- a/lib/activeadmin-translate.rb
+++ b/lib/activeadmin-translate.rb
@@ -1,5 +1,5 @@
 require 'active_admin'
-require 'globalize3'
+require 'globalize'
 
 require 'active_admin/version'
 require 'active_admin/translate/engine'


### PR DESCRIPTION
I removed 'form_buffers' function because It has been removed from ActiveAdmin::FormBuilder in last version. 

See: 'https://github.com/activeadmin/activeadmin/blob/d775bb9edfc96c0d64bdde375fc3db697b77d728/lib/active_admin/views/components/active_admin_form.rb'
