### PR TITLE
Added locale to forms

### DIFF
--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -13,7 +13,4 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
   gem.version       = ActiveAdmin::Translate::VERSION
 
-  gem.add_dependency 'activeadmin'
-  gem.add_dependency 'globalize3'
-  gem.add_dependency 'railties'
 end

--- a/activeadmin-translate.gemspec
+++ b/activeadmin-translate.gemspec
@@ -13,4 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
   gem.version       = ActiveAdmin::Translate::VERSION
 
+  gem.add_dependency 'activeadmin'
+  gem.add_dependency 'globalize3'
+  gem.add_dependency 'railties'
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.3'
+    VERSION = '0.2.4'
   end
 end

--- a/lib/active_admin/translate/version.rb
+++ b/lib/active_admin/translate/version.rb
@@ -1,6 +1,6 @@
 module ActiveAdmin
   module Translate
     # The current released version
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end

--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
               end
             end
             td :width => 1 do
-              raw("<b>#{locale}</b>")
+              raw("<b>#{locale.upcase}</b>")
             end
             td do
               ::I18n.with_locale locale do

--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -18,7 +18,7 @@ module ActiveAdmin
               end
             end
             td :width => 1 do
-              "<b>#{locale}</b>".raw
+              raw("<b>#{locale}</b>")
             end
             td do
               ::I18n.with_locale locale do

--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -17,6 +17,9 @@ module ActiveAdmin
                 header_content_for(attr)
               end
             end
+            td :width => 1 do
+              "<b>#{locale}</b>".raw
+            end
             td do
               ::I18n.with_locale locale do
                 content_for(block || attr)


### PR DESCRIPTION
When listing translated fields under an object using `translate_attributes_table_for`, we had no way to know which content belonged to which locale.

Added locale identifier before each translated field.

Sample: ![Sample](http://i.imgur.com/17SK4kk.png)
